### PR TITLE
PR for #40 - Bug with UWP networking components

### DIFF
--- a/MADE.App.Networking/NetworkRequestManager.cs
+++ b/MADE.App.Networking/NetworkRequestManager.cs
@@ -23,11 +23,7 @@ namespace MADE.App.Networking
     /// </summary>
     public sealed class NetworkRequestManager : INetworkRequestManager
     {
-#if WINDOWS_UWP
-        private readonly Windows.UI.Xaml.DispatcherTimer processTimer;
-#else
         private Timer processTimer;
-#endif
 
         private bool isProcessingRequests;
 
@@ -37,11 +33,6 @@ namespace MADE.App.Networking
         public NetworkRequestManager()
         {
             this.CurrentQueue = new ConcurrentDictionary<string, NetworkRequestCallback>();
-
-#if WINDOWS_UWP
-            this.processTimer = new Windows.UI.Xaml.DispatcherTimer { Interval = TimeSpan.FromMinutes(1) };
-            this.processTimer.Tick += (sender, o) => this.ProcessCurrentQueue();
-#endif
         }
 
         /// <summary>
@@ -65,14 +56,6 @@ namespace MADE.App.Networking
         /// </param>
         public void Start(TimeSpan processPeriod)
         {
-#if WINDOWS_UWP
-            this.processTimer.Interval = processPeriod;
-
-            if (!this.processTimer.IsEnabled)
-            {
-                this.processTimer.Start();
-            }
-#else
             if (this.processTimer == null)
             {
                 this.processTimer = new Timer(
@@ -85,7 +68,6 @@ namespace MADE.App.Networking
             {
                 this.processTimer.Change(TimeSpan.FromMinutes(0), processPeriod);
             }
-#endif
         }
 
         /// <summary>
@@ -93,14 +75,7 @@ namespace MADE.App.Networking
         /// </summary>
         public void Stop()
         {
-#if WINDOWS_UWP
-            if (this.processTimer.IsEnabled)
-            {
-                this.processTimer.Stop();
-            }
-#else
             this.processTimer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
-#endif
         }
 
         /// <summary>

--- a/MADE.App.Networking/Requests/Json/JsonDeleteNetworkRequest.cs
+++ b/MADE.App.Networking/Requests/Json/JsonDeleteNetworkRequest.cs
@@ -9,17 +9,6 @@
 
 namespace MADE.App.Networking.Requests.Json
 {
-#if WINDOWS_UWP
-    using System;
-    using System.Collections.Generic;
-    using System.Threading;
-    using System.Threading.Tasks;
-
-    using Windows.Web.Http;
-
-    using Newtonsoft.Json;
-
-#else
     using System;
     using System.Collections.Generic;
     using System.Net.Http;
@@ -27,7 +16,6 @@ namespace MADE.App.Networking.Requests.Json
     using System.Threading.Tasks;
 
     using Newtonsoft.Json;
-#endif
 
     /// <summary>
     /// Defines a network request for a DELETE call with a JSON response.
@@ -128,15 +116,6 @@ namespace MADE.App.Networking.Requests.Json
                 }
             }
 
-#if WINDOWS_UWP
-            HttpResponseMessage response = cts == null
-                                               ? await this.client.SendRequestAsync(
-                                                     request,
-                                                     HttpCompletionOption.ResponseHeadersRead)
-                                               : await this.client.SendRequestAsync(
-                                                     request,
-                                                     HttpCompletionOption.ResponseHeadersRead).AsTask(cts.Token);
-#else
             HttpResponseMessage response = cts == null
                                                ? await this.client.SendAsync(
                                                      request,
@@ -145,7 +124,6 @@ namespace MADE.App.Networking.Requests.Json
                                                      request,
                                                      HttpCompletionOption.ResponseHeadersRead,
                                                      cts.Token);
-#endif
 
             response.EnsureSuccessStatusCode();
 

--- a/MADE.App.Networking/Requests/Json/JsonGetNetworkRequest.cs
+++ b/MADE.App.Networking/Requests/Json/JsonGetNetworkRequest.cs
@@ -9,17 +9,6 @@
 
 namespace MADE.App.Networking.Requests.Json
 {
-#if WINDOWS_UWP
-    using System;
-    using System.Collections.Generic;
-    using System.Threading;
-    using System.Threading.Tasks;
-
-    using Windows.Web.Http;
-
-    using Newtonsoft.Json;
-
-#else
     using System;
     using System.Collections.Generic;
     using System.Net.Http;
@@ -27,7 +16,6 @@ namespace MADE.App.Networking.Requests.Json
     using System.Threading.Tasks;
 
     using Newtonsoft.Json;
-#endif
 
     /// <summary>
     /// Defines a network request for a GET call with a JSON response.
@@ -128,15 +116,6 @@ namespace MADE.App.Networking.Requests.Json
                 }
             }
 
-#if WINDOWS_UWP
-            HttpResponseMessage response = cts == null
-                                               ? await this.client.SendRequestAsync(
-                                                     request,
-                                                     HttpCompletionOption.ResponseHeadersRead)
-                                               : await this.client.SendRequestAsync(
-                                                     request,
-                                                     HttpCompletionOption.ResponseHeadersRead).AsTask(cts.Token);
-#else
             HttpResponseMessage response = cts == null
                                                ? await this.client.SendAsync(
                                                      request,
@@ -145,7 +124,6 @@ namespace MADE.App.Networking.Requests.Json
                                                      request,
                                                      HttpCompletionOption.ResponseHeadersRead,
                                                      cts.Token);
-#endif
 
             response.EnsureSuccessStatusCode();
 

--- a/MADE.App.Networking/Requests/Json/JsonPatchNetworkRequest.cs
+++ b/MADE.App.Networking/Requests/Json/JsonPatchNetworkRequest.cs
@@ -7,16 +7,14 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
-#if WINDOWS_UWP
 namespace MADE.App.Networking.Requests.Json
 {
     using System;
     using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
-
-    using Windows.Storage.Streams;
-    using Windows.Web.Http;
 
     using MADE.App.Networking.Requests;
 
@@ -142,13 +140,15 @@ namespace MADE.App.Networking.Requests.Json
 
             Uri uri = new Uri(this.Url);
 
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Patch, uri)
-                              {
-                                  Content = new HttpStringContent(
-                                      this.Data,
-                                      UnicodeEncoding.Utf8,
-                                      "application/json")
-                              };
+            HttpRequestMessage request = new HttpRequestMessage
+                                             {
+                                                 Method = new HttpMethod("PATCH"),
+                                                 RequestUri = uri,
+                                                 Content = new StringContent(
+                                                     this.Data,
+                                                     Encoding.UTF8,
+                                                     "application/json")
+                                             };
 
             if (this.Headers != null)
             {
@@ -159,9 +159,13 @@ namespace MADE.App.Networking.Requests.Json
             }
 
             HttpResponseMessage response = cts == null
-                               ? await this.client.SendRequestAsync(request, HttpCompletionOption.ResponseHeadersRead)
-                               : await this.client.SendRequestAsync(request, HttpCompletionOption.ResponseHeadersRead)
-                                     .AsTask(cts.Token);
+                                               ? await this.client.SendAsync(
+                                                     request,
+                                                     HttpCompletionOption.ResponseHeadersRead)
+                                               : await this.client.SendAsync(
+                                                     request,
+                                                     HttpCompletionOption.ResponseHeadersRead,
+                                                     cts.Token);
 
             response.EnsureSuccessStatusCode();
 
@@ -169,4 +173,3 @@ namespace MADE.App.Networking.Requests.Json
         }
     }
 }
-#endif

--- a/MADE.App.Networking/Requests/Json/JsonPostNetworkRequest.cs
+++ b/MADE.App.Networking/Requests/Json/JsonPostNetworkRequest.cs
@@ -9,18 +9,6 @@
 
 namespace MADE.App.Networking.Requests.Json
 {
-#if WINDOWS_UWP
-    using System;
-    using System.Collections.Generic;
-    using System.Threading;
-    using System.Threading.Tasks;
-
-    using Windows.Storage.Streams;
-    using Windows.Web.Http;
-
-    using Newtonsoft.Json;
-
-#else
     using System;
     using System.Collections.Generic;
     using System.Net.Http;
@@ -29,8 +17,6 @@ namespace MADE.App.Networking.Requests.Json
     using System.Threading.Tasks;
 
     using Newtonsoft.Json;
-
-#endif
 
     /// <summary>
     /// Defines a network request for a POST call with a JSON response.
@@ -152,17 +138,6 @@ namespace MADE.App.Networking.Requests.Json
 
             Uri uri = new Uri(this.Url);
 
-#if WINDOWS_UWP
-
-            var request = new HttpRequestMessage(HttpMethod.Post, uri)
-                              {
-                                  Content =
-                                      new HttpStringContent(
-                                          this.Data,
-                                          UnicodeEncoding.Utf8,
-                                          "application/json")
-                              };
-#else
             HttpRequestMessage request =
                 new HttpRequestMessage(HttpMethod.Post, uri)
                     {
@@ -171,7 +146,6 @@ namespace MADE.App.Networking.Requests.Json
                             Encoding.UTF8,
                             "application/json")
                     };
-#endif
 
             if (this.Headers != null)
             {
@@ -181,15 +155,6 @@ namespace MADE.App.Networking.Requests.Json
                 }
             }
 
-#if WINDOWS_UWP
-            HttpResponseMessage response = cts == null
-                                               ? await this.client.SendRequestAsync(
-                                                     request,
-                                                     HttpCompletionOption.ResponseHeadersRead)
-                                               : await this.client.SendRequestAsync(
-                                                     request,
-                                                     HttpCompletionOption.ResponseHeadersRead).AsTask(cts.Token);
-#else
             HttpResponseMessage response = cts == null
                                                ? await this.client.SendAsync(
                                                      request,
@@ -198,7 +163,6 @@ namespace MADE.App.Networking.Requests.Json
                                                      request,
                                                      HttpCompletionOption.ResponseHeadersRead,
                                                      cts.Token);
-#endif
 
             response.EnsureSuccessStatusCode();
 

--- a/MADE.App.Networking/Requests/Json/JsonPutNetworkRequest.cs
+++ b/MADE.App.Networking/Requests/Json/JsonPutNetworkRequest.cs
@@ -9,18 +9,6 @@
 
 namespace MADE.App.Networking.Requests.Json
 {
-#if WINDOWS_UWP
-    using System;
-    using System.Collections.Generic;
-    using System.Threading;
-    using System.Threading.Tasks;
-
-    using Windows.Storage.Streams;
-    using Windows.Web.Http;
-
-    using Newtonsoft.Json;
-
-#else
     using System;
     using System.Collections.Generic;
     using System.Net.Http;
@@ -29,8 +17,6 @@ namespace MADE.App.Networking.Requests.Json
     using System.Threading.Tasks;
 
     using Newtonsoft.Json;
-
-#endif
 
     /// <summary>
     /// Defines a network request for a PUT call with a JSON response.
@@ -115,7 +101,18 @@ namespace MADE.App.Networking.Requests.Json
             return JsonConvert.DeserializeObject<TResponse>(json);
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Executes the network request.
+        /// </summary>
+        /// <param name="expectedResponse">
+        /// The type expected by the response of the request.
+        /// </param>
+        /// <param name="cts">
+        /// The cancellation token source.
+        /// </param>
+        /// <returns>
+        /// Returns the response of the request as an object.
+        /// </returns>
         public override async Task<object> ExecuteAsync(Type expectedResponse, CancellationTokenSource cts = null)
         {
             string json = await this.GetJsonResponse(cts);
@@ -137,16 +134,6 @@ namespace MADE.App.Networking.Requests.Json
 
             Uri uri = new Uri(this.Url);
 
-#if WINDOWS_UWP
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Put, uri)
-                              {
-                                  Content =
-                                      new HttpStringContent(
-                                          this.Data,
-                                          UnicodeEncoding.Utf8,
-                                          "application/json")
-                              };
-#else
             HttpRequestMessage request =
                 new HttpRequestMessage(HttpMethod.Put, uri)
                     {
@@ -155,7 +142,6 @@ namespace MADE.App.Networking.Requests.Json
                             Encoding.UTF8,
                             "application/json")
                     };
-#endif
 
             if (this.Headers != null)
             {
@@ -165,15 +151,6 @@ namespace MADE.App.Networking.Requests.Json
                 }
             }
 
-#if WINDOWS_UWP
-            HttpResponseMessage response = cts == null
-                                               ? await this.client.SendRequestAsync(
-                                                     request,
-                                                     HttpCompletionOption.ResponseHeadersRead)
-                                               : await this.client.SendRequestAsync(
-                                                     request,
-                                                     HttpCompletionOption.ResponseHeadersRead).AsTask(cts.Token);
-#else
             HttpResponseMessage response = cts == null
                                                ? await this.client.SendAsync(
                                                      request,
@@ -182,7 +159,6 @@ namespace MADE.App.Networking.Requests.Json
                                                      request,
                                                      HttpCompletionOption.ResponseHeadersRead,
                                                      cts.Token);
-#endif
 
             response.EnsureSuccessStatusCode();
 

--- a/MADE.App.Networking/Requests/Streams/StreamGetNetworkRequest.cs
+++ b/MADE.App.Networking/Requests/Streams/StreamGetNetworkRequest.cs
@@ -7,15 +7,13 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
-#if WINDOWS_UWP
 namespace MADE.App.Networking.Requests.Streams
 {
     using System;
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
-
-    using Windows.Web.Http;
 
     using MADE.App.Networking.Requests;
 
@@ -117,14 +115,17 @@ namespace MADE.App.Networking.Requests.Streams
             }
 
             HttpResponseMessage response = cts == null
-                               ? await this.client.SendRequestAsync(request, HttpCompletionOption.ResponseHeadersRead)
-                               : await this.client.SendRequestAsync(request, HttpCompletionOption.ResponseHeadersRead)
-                                     .AsTask(cts.Token);
+                                               ? await this.client.SendAsync(
+                                                     request,
+                                                     HttpCompletionOption.ResponseHeadersRead)
+                                               : await this.client.SendAsync(
+                                                     request,
+                                                     HttpCompletionOption.ResponseHeadersRead,
+                                                     cts.Token);
 
             response.EnsureSuccessStatusCode();
 
-            return await response.Content.ReadAsInputStreamAsync();
+            return await response.Content.ReadAsStreamAsync();
         }
     }
 }
-#endif


### PR DESCRIPTION
Change Title
Removed the UWP specific logic from the networking components that was causing an issue with constructing from a .NET Standard library within a UWP application. 

Also updated the UWP only network request classes to be common across all platforms.

Associated Issues
#40 - [Bug] JSON network requests cannot be created in common layer running on UWP due to namespace difference