### PR TITLE
PR for #48 - Additional header text entry features

### DIFF
--- a/MADE.App.Views.Controls.TextEntry.Forms/TextEntry.xaml.cs
+++ b/MADE.App.Views.Controls.TextEntry.Forms/TextEntry.xaml.cs
@@ -32,11 +32,11 @@ namespace MADE.App.Views
             typeof(string),
             typeof(TextEntry),
             null,
-            propertyChanged: (bindable, ValueChangedEventArgs, newValue) =>
+            propertyChanged: (bindable, valueChangedEventArgs, newValue) =>
                 {
                     var control = (TextEntry)bindable;
                     control.TextEntryHeader.Text = (string)newValue;
-                    control.TextEntryHeader.IsVisible = !string.IsNullOrWhiteSpace(control.Header);
+                    control.UpdateHeaderVisibility(!string.IsNullOrWhiteSpace(control.Header));
                 });
 
         /// <summary>
@@ -110,7 +110,7 @@ namespace MADE.App.Views
             propertyChanged: (bindable, value, newValue) =>
             {
                 var control = (TextEntry)bindable;
-                control.TextEntryHeader.IsVisible = (bool)newValue;
+                control.UpdateHeaderVisibility((bool)newValue);
             });
 
         /// <summary>
@@ -198,6 +198,17 @@ namespace MADE.App.Views
         {
             get => (double)this.GetValue(TextBoxHeightProperty)'
             set => this.SetValue(TextBoxHeightProperty, value);
+        }
+
+        /// <summary>
+        /// Updates the header for the control based on the value passed in.
+        /// </summary>
+        /// <param name="isVisible">
+        /// The value indicating whther the header should be visible.
+        /// </param>
+        public void UpdateHeaderVisibility(bool isVisible)
+        {
+            this.TextEntryHeader.SetVisible(isVisible);
         }
 
         /// <summary>

--- a/MADE.App.Views.Controls.TextEntry.Forms/TextEntry.xaml.cs
+++ b/MADE.App.Views.Controls.TextEntry.Forms/TextEntry.xaml.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="TextEntry.xaml.cs" company="MADE Apps">
 //   Copyright (c) MADE Apps.
 // </copyright>
@@ -100,6 +100,20 @@ namespace MADE.App.Views
                 });
 
         /// <summary>
+        /// Defines the bindable property for the <see cref="IsHeaderVisible"/> value.
+        /// </summary>
+        public static readonly BindableProperty HeaderVisibleProperty = BindableProperty.Create(
+            nameof(IsHeaderVisible),
+            typeof(bool),
+            typeof(TextEntry),
+            true,
+            propertyChanged: (bindable, value, newValue) =>
+            {
+                var control = (TextEntry)bindable;
+                control.TextEntryHeader.IsVisible = (bool)newValue;
+            });
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="TextEntry"/> class.
         /// </summary>
         public TextEntry()
@@ -153,6 +167,15 @@ namespace MADE.App.Views
         {
             get => (Orientation)this.GetValue(OrientationProperty);
             set => this.SetValue(OrientationProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets whether the header is visible.
+        /// </summary>
+        public bool IsHeaderVisible
+        {
+            get => (bool)this.GetValue(HeaderVisibleProperty);
+            set => this.SetValue(HeaderVisibleProperty, value);
         }
 
         /// <summary>

--- a/MADE.App.Views.Controls.TextEntry.Forms/TextEntry.xaml.cs
+++ b/MADE.App.Views.Controls.TextEntry.Forms/TextEntry.xaml.cs
@@ -114,6 +114,19 @@ namespace MADE.App.Views
             });
 
         /// <summary>
+        /// Defines the bindable property for the <see cref="TextBoxHeight"/> value.
+        /// </summary>
+        public static readonly BindableProperty TextBoxHeightProperty = BindableProperty.Create(
+            nameof(TextBoxHeight),
+            typeof(double),
+            typeof(TextEntry),
+            propertyChanged: (bindable, value, newValue) =>
+            {
+                var control = (TextEntry)bindable;
+                control.TextEntryContent.HeightRequest = (double)newValue;
+            });
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="TextEntry"/> class.
         /// </summary>
         public TextEntry()
@@ -176,6 +189,15 @@ namespace MADE.App.Views
         {
             get => (bool)this.GetValue(HeaderVisibleProperty);
             set => this.SetValue(HeaderVisibleProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the height of the text box within the <see cref="TextEntry"/>
+        /// </summary>
+        public double TextBoxHeight
+        {
+            get => (double)this.GetValue(TextBoxHeightProperty)'
+            set => this.SetValue(TextBoxHeightProperty, value);
         }
 
         /// <summary>

--- a/MADE.App.Views.Controls.TextEntry.Forms/TextEntry.xaml.cs
+++ b/MADE.App.Views.Controls.TextEntry.Forms/TextEntry.xaml.cs
@@ -196,7 +196,7 @@ namespace MADE.App.Views
         /// </summary>
         public double TextBoxHeight
         {
-            get => (double)this.GetValue(TextBoxHeightProperty)'
+            get => (double)this.GetValue(TextBoxHeightProperty);
             set => this.SetValue(TextBoxHeightProperty, value);
         }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
> Please check one or more that apply to this PR

- [x] Bug fix
- [ ] Feature/change request
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build or CI related changes
- [ ] Other (include details)

## What has changed?
> Please describe, in detail, the changes made

This PR includes changes to the TextEntry control to add in two new features to allow more customization for users. These features include the ability to now customize:

- Text box height
The user can now define the height they would like for the text box within the text entry control, though this does not affect the size of the text for the header (This didn't seem necessary though as the header text size would generally be set though the HeaderStyle property.

- Header visibility
The user can now override whether the header should be visible or not, and isn't solely defined by whether the user has set text for the header.

Additionally, I have performed some code styling within this file, and updated areas where we would usually use `.IsVisible` to now use the extension for `.SetVisible` to allow for a more consistent way of doing this going forward.

## What platforms does this change affect?
> Please check one or more that apply for this PR

- [ ] Windows (UWP)
- [ ] Xamarin.Android
- [ ] Xamarin.iOS
- [x] Xamarin.Forms
- [ ] .NET Standard

## PR checklist
> Please check if your PR fulfils the following requirements:

- [ ] Tests have been added (where applicable)
- [x] Code styling has been run on all new source file changes
- [ ] Documentation has been added
- [ ] Code sample has been added
- [x] Contains **NO** breaking changes